### PR TITLE
DOPS-2591 Configure SonarQube on ADAR, add DefectDojo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,9 @@ def pipeline = new org.js.AppPipeline(steps: this,
     ipfsHashChatIDStage: '',
     ipfsHashChatIDProd: '',
     // ipfsHashChatID: '-1001375555544',
-    secretScannerExclusion: 'Jenkinsfile-UCAN|.*env.json\$|.*env-stage.json\$'
+    secretScannerExclusion: 'Jenkinsfile-UCAN|.*env.json\$|.*env-stage.json\$',
+    sonarSrcPath: 'src',
+    sonarTestsPath: 'tests',
+    // dojoProductType: 'sora'
 )
 pipeline.runPipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,6 @@ def pipeline = new org.js.AppPipeline(steps: this,
     secretScannerExclusion: 'Jenkinsfile-UCAN|.*env.json\$|.*env-stage.json\$',
     sonarSrcPath: 'src',
     sonarTestsPath: 'tests',
-    // dojoProductType: 'sora'
+    dojoProductType: 'Dev'
 )
 pipeline.runPipeline()


### PR DESCRIPTION
# Task

[DOPS-2591]: Configure SonarQube on ADAR, add DefectDojo.

## Changes

1. Set up SonarQube (there is no tests metrics because of temporary tests).
2. Connect to DefectDojo


[DOPS-2591]: https://soramitsu.atlassian.net/browse/DOPS-2591